### PR TITLE
Save and restore modification marks in NormalPasta

### DIFF
--- a/plugin/pasta.vim
+++ b/plugin/pasta.vim
@@ -9,7 +9,16 @@ let g:loaded_pasta = 1
 
 function! s:NormalPasta(p, o)
   if (getregtype() ==# "V")
-    exe "normal! " . a:o . "\<space>\<bs>\<esc>" . v:count1 . '"' . v:register . ']pk"_dd'
+    exe "normal! " . a:o . "\<space>\<bs>\<esc>" . v:count1 . '"' . v:register . ']p'
+    " Save the `[ and `] marks (point to the last modification)
+    let first = getpos("'[")
+    let last  = getpos("']")
+    normal! k"_dd
+    " Compensate the line we have just deleted
+    let first[1] -= 1
+    let last[1]  -= 1
+    call setpos("'[", first)
+    call setpos("']", last)
   else
     exe "normal! " . v:count1 . '"' . v:register . a:p
   endif


### PR DESCRIPTION
Hi.

Hopefully this commit fixes Issue#2. I just saved the '[ and '] registers and restored them after deleting the empty line. I've only fixed it for normal mode since I never find myself pasting in visual mode, so I don't feel confident to test a fix. If I ever feel the need will see if I end up with another request. :)

Thank you.
