### PR TITLE
Don't overwrite reg when pasting in visual character-wise mode

### DIFF
--- a/plugin/pasta.vim
+++ b/plugin/pasta.vim
@@ -35,7 +35,7 @@ function! s:VisualPasta()
     " workaround strange Vim behavior (""p is no-op in visual mode)
     let reg = v:register == '"' ? '' : '"' . v:register
 
-    exe "normal! gv" . v:count1 . reg . "p"
+    exe "normal! gv" . v:count1 . reg . 'pgv"'.v:register.'y`>'
   endif
 endfunction
 


### PR DESCRIPTION
When pasting text in visual character-wise mode, the register containing this text is overwritten with the text that was copied over. I find this behavior very annoying because in many cases you want to paste the same text in a few places. This is not the case when pasting in visual line-wise mode. Based on this [post](https://stackoverflow.com/questions/290465/how-to-paste-over-without-overwriting-register) I see that I'm not the only one that is unhappy with this default behavior.

I was wondering if you would be interested in adding this feature to your plugin.
If you do then I could wrap it in an option so that users can optionally enable it.